### PR TITLE
Jsの導入、prototypeの写真表示機能の導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'coffee-rails', '~> 4.1.0'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem 'turbolinks'
+#gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,9 +183,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
-    turbolinks (5.0.1)
-      turbolinks-source (~> 5)
-    turbolinks-source (5.0.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.2)
@@ -219,7 +216,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring
-  turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,5 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require bootstrap-sprockets
 //= require_tree .

--- a/app/assets/javascripts/previewImage.js
+++ b/app/assets/javascripts/previewImage.js
@@ -1,0 +1,17 @@
+$(function(){
+  //id（#js-image-preview）をeachで回しても要素は一つしか取得できない。複数要素にidをつけたとしても。classなら要素を複数取れる。
+  $('.js-image-preview').each(function(){
+    var prototype_image = $(this).find('input[type=file]');
+    var image_tag = $(this).find('img');
+
+    prototype_image.change(function(e){
+      var file = e.target.files[0];//eachのindexじゃダメ。常に0
+      var reader = new FileReader();
+
+      reader.readAsDataURL(file);
+      reader.onload = function(){
+        image_tag.attr("src",reader.result)
+      }
+    });
+  });
+});

--- a/app/assets/javascripts/previewImage.js
+++ b/app/assets/javascripts/previewImage.js
@@ -10,8 +10,8 @@ $(function(){
 
       reader.readAsDataURL(file);
       reader.onload = function(){
-        image_tag.attr("src",reader.result)
-      }
+        image_tag.attr("src",reader.result);
+      };
     });
   });
 });

--- a/app/assets/stylesheets/protospace.css.scss
+++ b/app/assets/stylesheets/protospace.css.scss
@@ -634,3 +634,19 @@ body {
   height: 10px;
   text-align: center;
 }
+
+.prototype-image{
+  height: 100%;
+  width: 100%;
+}
+
+.avatar-image{
+  //円を作る
+  border-radius: 50%;
+  width: 75px;
+  height: 75px;
+  //親との相対位置
+  position: relative;
+  right: 16px;
+  bottom: 2px;
+}

--- a/app/assets/stylesheets/protospace.css.scss
+++ b/app/assets/stylesheets/protospace.css.scss
@@ -292,9 +292,10 @@ body {
   .thumbnail {
     border-radius: 0;
     padding: 0;
+    position: relative;
 
     .thumbnail-link {
-      float: right;
+      position: absolute;
     }
 
   }

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -7,7 +7,8 @@
         .user-name_image.row
           .user-name.col-md-10
             =f.text_field :name,placeholder: "username"
-          .user-image.col-md-2
+          .user-image.col-md-2.js-image-preview
+            =image_tag "", class: "avatar-image"
             =button_tag(class: "btn btn-primary") do
               Add image
               =f.file_field :avatar

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,8 +3,8 @@
   %head
     %meta{content: "text/html; charset=US-ASCII", "http-equiv" => "Content-Type"}/
     %title Protospace
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
-    = javascript_include_tag 'application', 'data-turbolinks-track' => true
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
     = csrf_meta_tags
   %body
     -if notice

--- a/app/views/prototypes/_prototype.html.haml
+++ b/app/views/prototypes/_prototype.html.haml
@@ -13,7 +13,7 @@
               %li
                 =link_to("削除", prototype_path(prototype), method: :delete)
 
-    = link_to image_tag(prototype.images[0]), prototype_path(prototype)
+    = link_to image_tag(prototype.images[0].image.url), prototype_path(prototype)
     .caption
       %h3 #{prototype.title}
       .proto-meta

--- a/app/views/prototypes/edit.html.haml
+++ b/app/views/prototypes/edit.html.haml
@@ -6,18 +6,20 @@
           =f.text_field :title,placeholder: "Title", class:"proto-new-title"
       .row
         .col-md-12
-          .cover-image-upload
+          .cover-image-upload.js-image-preview
             =f.fields_for :images, @main_image do |image|
               =image.file_field :image
               =image.hidden_field :status, value: "main"
+              =image_tag @main_image[0].image.url, class: "prototype-image"
         .col-md-12
           %ul.proto-sub-list.list-group
-            -@sub_images.each do |sub_image|
-              %li.list-group-item.col-md-4
+            -@sub_images.each.with_index do |sub_image,i|
+              %li.list-group-item.col-md-4.js-image-preview
                 .image-upload
                   = f.fields_for :images, sub_image do |image|
                     =image.file_field :image
                     =image.hidden_field :status, value: "sub"
+                    =image_tag sub_image.image.url, class: "prototype-image"
             %li.list-group-item.col-md-4
               .image-upload-plus
                 %span +

--- a/app/views/prototypes/edit.html.haml
+++ b/app/views/prototypes/edit.html.haml
@@ -13,7 +13,7 @@
               =image_tag @main_image[0].image.url, class: "prototype-image"
         .col-md-12
           %ul.proto-sub-list.list-group
-            -@sub_images.each do |sub_image|
+            -@sub_images.each.with_index do |sub_image,i|
               %li.list-group-item.col-md-4.js-image-preview
                 .image-upload
                   = f.fields_for :images, sub_image do |image|

--- a/app/views/prototypes/edit.html.haml
+++ b/app/views/prototypes/edit.html.haml
@@ -13,7 +13,7 @@
               =image_tag @main_image[0].image.url, class: "prototype-image"
         .col-md-12
           %ul.proto-sub-list.list-group
-            -@sub_images.each.with_index do |sub_image,i|
+            -@sub_images.each do |sub_image|
               %li.list-group-item.col-md-4.js-image-preview
                 .image-upload
                   = f.fields_for :images, sub_image do |image|

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -13,21 +13,20 @@
           =f.text_field :title,placeholder: "Title", class:"proto-new-title" ,required: true
       .row
         .col-md-12
-          .cover-image-upload
+          .cover-image-upload.js-image-preview
             =f.fields_for :images do |image|
               =image.file_field :image ,required: true
               =image.hidden_field :status, value: "main"
+              =image_tag "", class: "prototype-image"
         .col-md-12
           %ul.proto-sub-list.list-group
-            -2.times do
+            -3.times do
               %li.list-group-item.col-md-4
-                .image-upload
+                .image-upload.js-image-preview
                   = f.fields_for :images do |image|
                     =image.file_field :image
                     =image.hidden_field :status, value: "sub"
-            %li.list-group-item.col-md-4
-              .image-upload-plus
-                %span +
+                    =image_tag "", class: "prototype-image"
       .row.proto-description
         .col-md-12
           =f.text_field :catch_copy,placeholder: "Catch Copy" ,required: true

--- a/app/views/prototypes/show.html.haml
+++ b/app/views/prototypes/show.html.haml
@@ -16,12 +16,12 @@
 
     .row
     .col-md-9
-      = image_tag(@main_image, class: 'img-responsive')
+      = image_tag(@main_image[0].image.url, class: 'img-responsive')
     .col-md-3
       %ul.proto-sub-list.list-group
-        -@sub_images.each do |sub_image|
+        -@sub_images.each.with_index do |sub_image,i|
           %li.list-group-item
-            = image_tag(sub_image, class: 'img-responsive')
+            = image_tag(sub_image.image.url, class: 'img-responsive')
   .row.proto-description
     .col-md-3
       %h4 Catch Copy

--- a/app/views/prototypes/show.html.haml
+++ b/app/views/prototypes/show.html.haml
@@ -14,7 +14,7 @@
     .col-md-6.text-right#like-count
       =render "likes/likes_link", prototype:@prototype
 
-    .row
+  .row
     .col-md-9
       = image_tag(@main_image[0].image.url, class: 'img-responsive')
     .col-md-3

--- a/app/views/prototypes/show.html.haml
+++ b/app/views/prototypes/show.html.haml
@@ -19,7 +19,7 @@
       = image_tag(@main_image[0].image.url, class: 'img-responsive')
     .col-md-3
       %ul.proto-sub-list.list-group
-        -@sub_images.each.with_index do |sub_image,i|
+        -@sub_images.each do |sub_image|
           %li.list-group-item
             = image_tag(sub_image.image.url, class: 'img-responsive')
   .row.proto-description


### PR DESCRIPTION
# WHAT
- JSを導入し、ユーザーの新規作成時のアバターの写真及び、prototypeの投稿、編集時のprototypeの写真のプレビュー機能を追加
- topページ及び、prototypeの個別ページでのprototypeの写真の表示機能を追加
# WHY

現在自分が選択した写真がプレビューできた方がより直感的に操作できるため。
